### PR TITLE
add 0.3 second request interval

### DIFF
--- a/tap_elasticsearch/client.py
+++ b/tap_elasticsearch/client.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import re
+import time
 import typing as t
 from pathlib import Path
 from typing import Any, Callable, Iterable
 
 import requests
 from requests import Response
+from singer_sdk import metrics
 from singer_sdk.helpers.jsonpath import extract_jsonpath
 from singer_sdk.pagination import BaseAPIPaginator
 from singer_sdk.streams import RESTStream
@@ -149,6 +151,36 @@ class TapelasticsearchStream(RESTStream):
         if next_page_token:
             params["search_after"] = next_page_token
         return params
+
+    def request_records(self, context: dict | None) -> t.Iterable[dict]:
+        """Request records from REST endpoint(s), returning response records.
+
+        If pagination is detected, pages will be recursed automatically.
+
+        Args:
+            context: Stream partition or context dictionary.
+
+        Yields:
+            An item for every record in the response.
+        """
+        paginator = self.get_new_paginator()
+        decorated_request = self.request_decorator(self._request)
+
+        with metrics.http_request_counter(self.name, self.path) as request_counter:
+            request_counter.context = context
+
+            while not paginator.finished:
+                prepared_request = self.prepare_request(
+                    context,
+                    next_page_token=paginator.current_value,
+                )
+                resp = decorated_request(prepared_request, context)
+                request_counter.increment()
+                self.update_sync_costs(prepared_request, resp, context)
+                yield from self.parse_response(resp)
+
+                time.sleep(0.3)
+                paginator.advance(resp)
 
     def parse_response(self, response: requests.Response) -> Iterable[dict]:
         """Parse the response and return an iterator of result records.

--- a/tap_elasticsearch/client.py
+++ b/tap_elasticsearch/client.py
@@ -179,7 +179,7 @@ class TapelasticsearchStream(RESTStream):
                 self.update_sync_costs(prepared_request, resp, context)
                 yield from self.parse_response(resp)
 
-                time.sleep(0.3)
+                time.sleep(self.config.get("request_interval"))
                 paginator.advance(resp)
 
     def parse_response(self, response: requests.Response) -> Iterable[dict]:

--- a/tap_elasticsearch/tap.py
+++ b/tap_elasticsearch/tap.py
@@ -33,6 +33,12 @@ class Tapelasticsearch(Tap):
             th.StringType,
             description="The start date",
         ),
+        th.Property(
+            "request_interval",
+            th.floatType,
+            description="The interval between requests",
+            default=0,
+        ),
     ).to_dict()
 
     def discover_streams(self) -> list[Stream]:


### PR DESCRIPTION
update the `request_records` method to insert a small gap between requests, per [Slack conversation](https://voxmedia.slack.com/archives/CSXCQR0CD/p1691438148546449) regarding updating the Meltano schedule that uses this extractor to run every hour ([relevant PR](https://github.com/nymag/data-dagster/pull/348))