### PR TITLE
Generic schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 .pyre/
 
 .DS_Store
+
+# IDE
+.idea

--- a/meltano.yml
+++ b/meltano.yml
@@ -5,4 +5,26 @@ default_environment: test
 environments:
 - name: test
 plugins:
-
+  extractors:
+  - name: tap-elasticsearch
+    namespace: tap_elasticsearch
+    pip_url: -e .
+    capabilities:
+    - state
+    - catalog
+    - discover
+    - about
+    - stream-maps
+    settings:
+    - name: page_size
+      kind: integer
+    - name: url_base
+      kind: string
+    - name: start_date
+      kind: string
+    - name: request_interval
+      kind: integer
+  loaders:
+  - name: target-jsonl
+    variant: andyh1203
+    pip_url: target-jsonl

--- a/tap_elasticsearch/tap.py
+++ b/tap_elasticsearch/tap.py
@@ -10,6 +10,49 @@ from singer_sdk import typing as th  # JSON schema typing helpers
 from tap_elasticsearch.client import TapelasticsearchStream
 
 
+generic_schema = {
+    "properties": {
+        "_index": {
+            "type": [
+                "string",
+                "null"
+            ]
+        },
+        "_id": {
+            "type": [
+                "string",
+                "null"
+            ]
+        },
+        "_type": {
+            "type": [
+                "string",
+                "null"
+            ]
+        },
+        "_score": {
+            "type": [
+                "number",
+                "null"
+            ]
+        },
+        "sort": {
+            "type": [
+                "array",
+                "null"
+            ]
+        },
+        "_source": {
+            "type": [
+                "object",
+                "null"
+            ]
+        },
+    },
+    "type": "object",
+}
+
+
 class Tapelasticsearch(Tap):
     """tap-elasticsearch tap class."""
 
@@ -54,23 +97,28 @@ class Tapelasticsearch(Tap):
             raise RuntimeError(aliases)
 
         alias_names = []
-        for v in aliases.values():
+        for k, v in aliases.items():
             if v["aliases"]:
                 alias_names.extend(v["aliases"])
+            else:
+                alias_names.append(k)
         # included_indices = self.config.get("included_indices", [])  # noqa: ERA001
-        catalog_dict = {
-            s["stream"]: s for s in self.input_catalog.to_dict().get("streams", {})
-        }
+        catalog_dict = {}
+        if self.input_catalog:
+            catalog_dict = {
+                s["stream"]: s for s in self.input_catalog.to_dict().get("streams", {})
+            }
         for alias in alias_names:
+            schema = {}
             try:
                 if not catalog_dict[alias]:
-                    continue
+                    schema = generic_schema
             except KeyError:
-                continue
+                schema = generic_schema
             stream = TapelasticsearchStream(
                 tap=self,
                 name=alias,
-                schema=catalog_dict[alias]["schema"],
+                schema=schema if schema else catalog_dict[alias]["schema"],
                 path=f"/{alias}/_search",
             )
             stream.apply_catalog(self.catalog)

--- a/tap_elasticsearch/tap.py
+++ b/tap_elasticsearch/tap.py
@@ -49,6 +49,10 @@ class Tapelasticsearch(Tap):
         except ConnectionError as e:
             msg = "Could not connect to Elasticsearch instance."
             raise RuntimeError(msg) from e
+
+        if "error" in aliases:
+            raise RuntimeError(aliases)
+
         alias_names = []
         for v in aliases.values():
             if v["aliases"]:


### PR DESCRIPTION
# The issue
Stream discover only works for use cases where an catalog is provided as an input. My use case doesn't care so much about the input catalog (which would take a long time to generate) as it is about getting the data comprehensively.

The current `discover_streams` method relies on a list of `aliases` returned from elasticsearch for each of the indexes. This also does not fit my use case. None of our indexes have aliases.

# This solution
Here I provide edits to the `discover_streams` method that, for me at least, enables me to discover the full list of indexes whether or not they have aliases and extract each index with default elasticsearch-based record keys. This will require the downstream target to be able to ingest json objects or otherwise require some other meltano based methodology for flattening.